### PR TITLE
Fix decimal mask digits parameter

### DIFF
--- a/lib/utils/masks/decimal-mask.ts
+++ b/lib/utils/masks/decimal-mask.ts
@@ -1,7 +1,6 @@
 import { onlyNumbers } from "../formatters/only-numbers";
 
-export const decimalMask = (value: string, digits?: number) => {
-  digits = 2;
+export const decimalMask = (value: string, digits: number = 2) => {
 
   const numericValue = onlyNumbers(value);
 


### PR DESCRIPTION
## Summary
- handle optional digits in decimal mask properly

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685562091ea88329bcf1de5aeb8c51a3